### PR TITLE
creating a PR template file

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,19 @@
+## I am a nice teammate so I've checked these:
+- [ ] I had followed the "From Local to PR submission guide".
+- [ ] I wrote a descriptive feature name title for the PR.
+- [ ] I had listed out the changes I made in this PR in clear, bullet points form.
+- [ ] I had connected or assign the PR to the related feature-issue by `Issue #<issue number>`(create one if there's none)
+- [ ] My code is tested locally.
+- [ ] I had assign a teammate or teammates to review the PR.
+- [ ] I had specify who to merge the PR.
+
+## What this PR do
+
+## This PR might affect whose code
+
+## Changes I made
+
+## Coonected Issue and Person to merge
+
+
+


### PR DESCRIPTION
## I am a nice teammate so I've checked these:
- [x] I had followed the "From Local to PR submission guide".
- [x] I wrote a descriptive feature name title for the PR.
- [x] I had listed out the changes I made in this PR in clear, bullet points form.
- [x] I had connected or assigned the PR to the related feature-issue by `Issue #<issue number>`(create one if there's none)
- [x] My code is tested locally.
- [x] I had assigned a teammate or teammates to review the PR.
- [x] I had specified who to merge the PR.

## What this PR does
Standardize PR submission for better communication by creating a template.

## This PR might affect whose code
None

## Changes I made
- Created a `pull_request_template.md`

## Connected Issue and Person to merge
- Connected with Issue #34 
- Whoever is the last person to review may merge this PR
