### PR TITLE
Fix: Set timer to zero from the start

### DIFF
--- a/css/pomodoro.css
+++ b/css/pomodoro.css
@@ -2,7 +2,6 @@
 #pomodoro-modal {
     position: absolute;
     z-index: 99;
-    opacity: 0.8;
     width: 360px;
     height: 500px;
     visibility: hidden;
@@ -112,6 +111,11 @@
 }
 
 /* Modifiers */
+
+.btn:active {
+    transform: translateY(2px);
+}
+
 .timer_btn {
     box-shadow: 0 4px rgb(26, 26, 26);
 }
@@ -119,7 +123,6 @@
 .timer_btn:active {
     box-shadow: none;
     background-color: rgb(27, 27, 27);
-    transform: translateY(2px);
 }
 
 .work_btn {

--- a/index.html
+++ b/index.html
@@ -73,22 +73,22 @@
 		<!-- Pomodoro Modal -->
 		<div id="pomodoro-modal">
 				<div id="time">
-					<span id="timer__minutes">25</span>
+					<span id="timer__minutes">00</span>
 					<span id="timer__colon">:</span>
 					<span id="timer__seconds">00</span>
 				</div>
 			<div id="options">
-				<span id="work" class="work_btn timer_btn">Work</span>
-				<span id="shortBreak" class="shortBreak_btn timer_btn">Short Break</span>
-				<span id="longBreak" class="longBreak_btn timer_btn">Long Break</span>
+				<span id="work" class="work_btn timer_btn btn">Work</span>
+				<span id="shortBreak" class="shortBreak_btn timer_btn btn">Short Break</span>
+				<span id="longBreak" class="longBreak_btn timer_btn btn">Long Break</span>
 			</div>
 			<div id="pdButtons">
-				<span href="#" id="stop"><i class="far fa-stop-circle"></i></span>
-				<div id="startTimer" class="timer_btn">
+				<span href="#" id="stop" class="btn"><i class="far fa-stop-circle"></i></span>
+				<div id="startTimer" class="timer_btn btn">
 					<span href="#" id="start"><i class="fas fa-play"></i></span>
 					<div id="progress"></div>
 				</div>
-				<span href="#" id="reset"><i class="fas fa-undo"></i></span>
+				<span href="#" id="reset" class="btn"><i class="fas fa-undo"></i></span>
 			</div>
 		</div>
 		<!-- End Pomodoro modal -->

--- a/js/pomodoro.js
+++ b/js/pomodoro.js
@@ -1,188 +1,191 @@
-
 let pomodoro = {
-    started : false,
-    isTimerRunning : false,
-    isWorkRunning : false,
-    isShortBreakRunning : false,
-    isLongBreakRunning : false,
-    minutes : 0,
-    seconds : 0,
+    started: false,
+    isTimerRunning: false,
+    isWorkRunning: false,
+    isShortBreakRunning: false,
+    isLongBreakRunning: false,
+    minutes: 0,
+    seconds: 0,
     progressHeight: 0,
     progressIncrement: 0,
-    interval : null,
-    breakDom : null,
-    minutesDom : null,
-    secondsDom : null,
-    progressDom : null,
-    init : function() {
-        let self = this;
-        this.minutesDom = document.getElementById('timer__minutes');
-        this.secondsDom = document.getElementById('timer__seconds');
-        this.progressDom = document.getElementById('progress');
-        this.interval = setInterval(function() {
-            self.intervalCallback.apply(self);
-        }, 1000);
-        this.pdWork = document.getElementById('work');
-        this.pdWork.onclick = function() {
-            self.startWork.apply(self);
-        };
-        this.pdShortBreak = document.getElementById('shortBreak');
-        this.pdShortBreak.onclick = function() {
-            self.startShortBreak.apply(self);
-        };
-        this.pdLongBreak = document.getElementById('longBreak');
-        this.pdLongBreak.onclick = function() {
-            self.startLongBreak.apply(self);
-        };
-        this.pdStart = document.getElementById('start');
-        this.pdStart.onclick = function() {
-            self.startTimer.apply(self);
-        };
-        this.pdReset = document.getElementById('reset');
-        this.pdReset.onclick = function() {
-            self.resetTimer.apply(self);
-        };
-        const pdStop = document.getElementById('stop');
-        pdStop.onclick = function() {
-            self.stopTimer.apply(self);
-        };
+    interval: null,
+    breakDom: null,
+    minutesDom: null,
+    secondsDom: null,
+    progressDom: null,
+    init: function() {
+      let self = this;
+      this.minutesDom = document.getElementById("timer__minutes");
+      this.secondsDom = document.getElementById("timer__seconds");
+      this.progressDom = document.getElementById("progress");
+      this.interval = setInterval(function() {
+        self.intervalCallback.apply(self);
+      }, 1000);
+      this.pdWork = document.getElementById("work");
+      this.pdWork.onclick = function() {
+        self.startWork.apply(self);
+        self.updateDom.apply(self);
+      };
+      this.pdShortBreak = document.getElementById("shortBreak");
+      this.pdShortBreak.onclick = function() {
+        self.startShortBreak.apply(self);
+        self.updateDom.apply(self);
+      };
+      this.pdLongBreak = document.getElementById("longBreak");
+      this.pdLongBreak.onclick = function() {
+        self.startLongBreak.apply(self);
+        self.updateDom.apply(self);
+      };
+      this.pdStart = document.getElementById("start");
+      this.pdStart.onclick = function() {
+        self.startTimer.apply(self);
+      };
+      this.pdReset = document.getElementById("reset");
+      this.pdReset.onclick = function() {
+        self.resetTimer.apply(self);
+      };
+      const pdStop = document.getElementById("stop");
+      pdStop.onclick = function() {
+        self.stopTimer.apply(self);
+      };
     },
-    resetVariables : function(mins, secs, started) {
-        this.minutes = mins;
-        this.seconds = secs;
-        this.started = started;
-        this.progressIncrement = 200/(this.minutes*60);
-        this.progressHeight = 0;
+    resetVariables: function(mins, secs, started) {
+      this.minutes = mins;
+      this.seconds = secs;
+      this.started = started;
+      this.progressIncrement = 200 / (this.minutes * 60);
+      this.progressHeight = 0;
     },
-
-    resetTimerDom : function(mins) {
-        this.minutesDom.innerHTML = mins;
-        this.secondsDom.innerHTML = "00";
+  
+    resetTimerDom: function(mins) {
+      this.minutesDom.innerHTML = mins;
+      this.secondsDom.innerHTML = "00";
     },
-
-    startTimer : function() {
-        if(this.isTimerRunning == false) {
-            this.isTimerRunning = true;
-            if (this.minutesDom.innerHTML == "25") {
-                this.resetVariables(25, 0, true);
-            } else if (this.minutesDom.innerHTML == "05") {
-                this.resetVariables(5, 0, true);
-            } else if (this.minutesDom.innerHTML == "15") {
-                this.resetVariables(15, 0, true);
-            }
+  
+    startTimer: function() {
+      if (this.isTimerRunning === false) {
+        this.isTimerRunning = true;
+        if (this.minutesDom.innerHTML === "25") {
+          this.resetVariables(25, 0, true);
+        } else if (this.minutesDom.innerHTML === "05") {
+          this.resetVariables(5, 0, true);
+        } else if (this.minutesDom.innerHTML === "15") {
+          this.resetVariables(15, 0, true);
         }
+      }
     },
-
-    startWork : function() {
-        this.isShortBreakRunning = false;
-        this.isLongBreakRunning = false;
-        this.isWorkRunning = true;
-        if (this.isTimerRunning) {
-            this.isTimerRunning = false;
-            this.resetTimerDom(25);
-            this.resetVariables(25, 0, true);
-        } else {
-            this.resetTimerDom(25);
-            this.resetVariables(25, 0, true);
-        }
-    },
-
-    startShortBreak : function() {
-        this.isLongBreakRunning = false;
-        this.isWorkRunning = false;
-        this.isShortBreakRunning = true;
-        if (this.isTimerRunning) {
-            this.isTimerRunning = false;
-            this.resetTimerDom(5);
-            this.resetVariables(5, 0, true);
-        } else {
-            this.resetTimerDom(5);
-            this.resetVariables(5, 0, true);
-        }
-    },
-
-    startLongBreak : function() {
-        this.isWorkRunning = false;
-        this.isShortBreakRunning = false;
-        this.isLongBreakRunning = true;
-        if (this.isTimerRunning) {
-            this.isTimerRunning = false;
-            this.resetTimerDom(15);
-            this.resetVariables(15, 0, true);
-        } else {
-            this.resetTimerDom(15);
-            this.resetVariables(15, 0, true);
-        }
-    },
-
-    resetTimer : function() {
-        if(this.isWorkRunning) {
-            this.resetTimerDom(25);
-            this.resetVariables(25, 0, false);
-            this.updateDom();
-        } else if (this.isLongBreakRunning) {
-            this.resetTimerDom(15);
-            this.resetVariables(15, 0, false);
-            this.updateDom();
-        } else if (this.isShortBreakRunning) {
-            this.resetTimerDom(5);
-            this.resetVariables(5, 0, false);
-            this.updateDom();
-        }
-    },
-
-    stopTimer : function() {
+  
+    startWork: function() {
+      this.isShortBreakRunning = false;
+      this.isLongBreakRunning = false;
+      this.isWorkRunning = true;
+      if (this.isTimerRunning) {
         this.isTimerRunning = false;
+        this.resetTimerDom(25);
+        this.resetVariables(25, 0, true);
+      } else {
+        this.resetTimerDom(25);
+        this.resetVariables(25, 0, true);
+      }
     },
-
-    toDoubleDigit : function(num) {
-        if(num < 10) {
-            return "0" + parseInt(num, 10);
+  
+    startShortBreak: function() {
+      this.isLongBreakRunning = false;
+      this.isWorkRunning = false;
+      this.isShortBreakRunning = true;
+      if (this.isTimerRunning) {
+        this.isTimerRunning = false;
+        this.resetTimerDom(5);
+        this.resetVariables(5, 0, true);
+      } else {
+        this.resetTimerDom(5);
+        this.resetVariables(5, 0, true);
+      }
+    },
+  
+    startLongBreak: function() {
+      this.isWorkRunning = false;
+      this.isShortBreakRunning = false;
+      this.isLongBreakRunning = true;
+      if (this.isTimerRunning) {
+        this.isTimerRunning = false;
+        this.resetTimerDom(15);
+        this.resetVariables(15, 0, true);
+      } else {
+        this.resetTimerDom(15);
+        this.resetVariables(15, 0, true);
+      }
+    },
+  
+    resetTimer: function() {
+      if (this.isWorkRunning) {
+        this.isTimerRunning = false;
+        this.resetTimerDom(25);
+        this.resetVariables(25, 0, false);
+        this.updateDom();
+      } else if (this.isLongBreakRunning) {
+        this.isTimerRunning = false;
+        this.resetTimerDom(15);
+        this.resetVariables(15, 0, false);
+        this.updateDom();
+      } else if (this.isShortBreakRunning) {
+        this.isTimerRunning = false;
+        this.resetTimerDom(5);
+        this.resetVariables(5, 0, false);
+        this.updateDom();
+      }
+    },
+  
+    stopTimer: function() {
+      this.isTimerRunning = false;
+    },
+  
+    toDoubleDigit: function(num) {
+      if (num < 10) {
+        return "0" + parseInt(num, 10);
+      }
+      return num;
+    },
+    updateDom: function() {
+      this.minutesDom.innerHTML = this.toDoubleDigit(this.minutes);
+      this.secondsDom.innerHTML = this.toDoubleDigit(this.seconds);
+      this.progressHeight = this.progressHeight + this.progressIncrement;
+      this.progressDom.style.height = this.progressHeight + "px";
+    },
+    intervalCallback: function() {
+      if (!this.started) return false;
+      if (this.isTimerRunning) {
+        if (this.seconds === 0) {
+          if (this.minutes === 0) {
+            this.timerComplete();
+            return;
+          }
+          this.seconds = 59;
+          this.minutes--;
+        } else {
+          this.seconds--;
         }
-        return num;
+        this.updateDom();
+      }
     },
-    updateDom : function() {
-        this.minutesDom.innerHTML = this.toDoubleDigit(this.minutes);
-        this.secondsDom.innerHTML = this.toDoubleDigit(this.seconds);
-        this.progressHeight = this.progressHeight + this.progressIncrement;
-        this.progressDom.style.height = this.progressHeight + 'px';
-    
-    },
-    intervalCallback : function() {
-        if(!this.started) return false;
-        if(this.isTimerRunning) {
-            if(this.seconds == 0) {
-                if(this.minutes == 0) {
-                    this.timerComplete();
-                    return;
-                }
-                this.seconds = 59;
-                this.minutes--;
-            } else {
-                this.seconds--;
-            }
-            this.updateDom();
-        }
-    },
-    timerComplete : function() {
-        this.started = false;
-        this.progressHeight = 0;
+    timerComplete: function() {
+      this.started = false;
+      this.progressHeight = 0;
     }
-};
-const modal_pomodoro = document.getElementById('pomodoro-modal');
-const icon_pomodoro = document.querySelectorAll('.pomodoro');
-
-icon_pomodoro.forEach(pdIcon => {
-    pdIcon.addEventListener('click', togglePomodoro);
-});
-
-let pdModal = document.getElementById('pomodoro-modal');
-function togglePomodoro() {
-    pdModal.style.visibility = (pdModal.style.visibility == "visible") ? "hidden" : "visible";
-}
-
-
-
-window.onload = function() {
+  };
+  const modal_pomodoro = document.getElementById("pomodoro-modal");
+  const icon_pomodoro = document.querySelectorAll(".pomodoro");
+  
+  icon_pomodoro.forEach(pdIcon => {
+    pdIcon.addEventListener("click", togglePomodoro);
+  });
+  
+  function togglePomodoro() {
+    modal_pomodoro.style.visibility =
+      modal_pomodoro.style.visibility === "visible" ? "hidden" : "visible";
+  }
+  
+  window.onload = function() {
     pomodoro.init();
-};
+  };
+  


### PR DESCRIPTION
The reset function was not working properly since `isWorkRunning` was false
and the `minutesDom` were set to 25 minutes. To avoid further bugs and
complicating the code, timer is set to 00 : 00 and allow user to select
the timer to run.

Couple of changes were also done on the `pomodoro.css` and `index.html`.

Issue #13

Please make sure these boxes are checked before submitting your feature pull request:
### Locally
- [x] I had followed the "From Local to PR submission guide".
- [x] I wrote a descriptive feature name tile for the PR.
- [x] I had listed out the changes I made in this PR in clear, bullet points form.
- [x] I had connected the PR to the related feature-issue (create one if there's none).
- [x] My code is tested locally.
  
 ### What does this PR do?
- Set the minutesDom to 00
- Fix conditions syntax
- Remove unused line of code
- Add animation to the reset and stop buttons
- update the pomodoro.css file to reflect the animations changes
 
 
 ## This PR might affect whose code.
previous pomodoro PR
 
 
 ## Changes I made
The ones above on "What does this PR do?"
